### PR TITLE
Update dependency versions in build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -63,10 +63,10 @@ lazy val `bibframe-entities` = (project in file("."))
     description := "Used to extract entities from the BIBFRAME-XML for purposes of enrichment from external sources",
     licenses += "Apache2" -> url("http://www.apache.org/licenses/LICENSE-2.0"),
     libraryDependencies ++= Seq(
-      "org.rogach"                    %% "scallop"              % "5.0.0",
+      "org.rogach"                    %% "scallop"              % "5.1.0",
       "org.scala-lang.modules"        %% "scala-xml"            % "2.2.0",
-      "org.hathitrust.htrc"           %% "scala-utils"          % "2.14.4",
-      "org.hathitrust.htrc"           %% "spark-utils"          % "1.5.4",
+      "org.hathitrust.htrc"           %% "scala-utils"          % "2.15.0",
+      "org.hathitrust.htrc"           %% "spark-utils"          % "1.6.0",
       "com.github.nscala-time"        %% "nscala-time"          % "2.32.0",
       "ch.qos.logback"                %  "logback-classic"      % "1.5.6",
       "org.codehaus.janino"           %  "janino"               % "3.1.12",


### PR DESCRIPTION
This commit updates the versions of 'scallop', 'scala-utils', and 'spark-utils' dependencies in build.sbt. These changes keep the project in line with the latest library updates ensuring better functionality and security.